### PR TITLE
feat: Zedエディタの設定をdotfilesで管理

### DIFF
--- a/initialize.zsh
+++ b/initialize.zsh
@@ -18,6 +18,18 @@ if [ ! -e "$HOME/.config/git" ]; then
   ln -fs "$HOME/dotfiles/git/" "$HOME/.config/git"
 fi
 
+if [ ! -e "$HOME/.config/zed/settings.json" ]; then
+  ln -fs "$HOME/dotfiles/zed/settings.json" "$HOME/.config/zed/settings.json"
+fi
+
+if [ ! -e "$HOME/.config/zed/keymap.json" ]; then
+  ln -fs "$HOME/dotfiles/zed/keymap.json" "$HOME/.config/zed/keymap.json"
+fi
+
+if [ ! -e "$HOME/.config/zed/tasks.json" ]; then
+  ln -fs "$HOME/dotfiles/zed/tasks.json" "$HOME/.config/zed/tasks.json"
+fi
+
 if [ ! -e "$HOME/.claude" ]; then
   ln -fs "$HOME/dotfiles/claude/" "$HOME/.claude"
 fi

--- a/zed/keymap.json
+++ b/zed/keymap.json
@@ -1,0 +1,55 @@
+// Zed keymap
+//
+// For information on binding keys, see the Zed
+// documentation: https://zed.dev/docs/key-bindings
+//
+// To see the default key bindings run `zed: open default keymap`
+// from the command palette.
+[
+  {
+    "context": "Workspace",
+    "bindings": {
+      // "shift shift": "file_finder::Toggle"
+    },
+  },
+  {
+    "context": "Editor && vim_mode == insert",
+    "bindings": {
+      // "j k": "vim::NormalBefore"
+    },
+  },
+  {
+    "context": "MessageEditor > Editor",
+    "bindings": {
+      "enter": "editor::Newline",
+      "cmd-enter": "agent::Chat",
+    },
+  },
+  {
+    "context": "!ContextEditor > (Editor && mode == full)",
+    "bindings": {
+      "cmd-g": "editor::GoToHunk",
+    },
+  },
+  {
+    "context": "!ContextEditor > (Editor && mode == full)",
+    "bindings": {
+      "cmd-shift-g": "editor::GoToPreviousHunk",
+    },
+  },
+  {
+    "context": "Editor",
+    "bindings": {
+      "cmd-b": "editor::GoToDefinition",
+      "cmd-alt-b": "editor::GoToImplementation",
+      "shift-f6": "editor::Rename",
+      "cmd-alt-l": "editor::Format",
+    },
+  },
+  {
+    "context": "Workspace",
+    "bindings": {
+      "cmd-`": "projects::OpenRecent",
+    },
+  },
+]

--- a/zed/settings.json
+++ b/zed/settings.json
@@ -1,0 +1,6 @@
+{
+  "buffer_font_family": ".ZedMono",
+  "theme": "JetBrains Dark",
+  "base_keymap": "JetBrains",
+  "autosave": "on_focus_change",
+}

--- a/zed/tasks.json
+++ b/zed/tasks.json
@@ -1,0 +1,8 @@
+[
+  {
+    "label": "Open LazyGit",
+    "command": "lazygit",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  }
+]


### PR DESCRIPTION
## 概要
Zedエディタの設定ファイルをdotfilesリポジトリで管理できるようにいたします。

## 追加ファイル
| ファイル | 内容 |
|---------|------|
| `zed/settings.json` | テーマ（JetBrains Dark）、フォント、オートセーブ設定 |
| `zed/keymap.json` | JetBrains風キーバインド |
| `zed/tasks.json` | LazyGitタスク |

## 変更ファイル
- `initialize.zsh`: Zed設定ファイルのシンボリックリンク作成処理を追加

## シンボリックリンク
```
~/.config/zed/settings.json -> ~/dotfiles/zed/settings.json
~/.config/zed/keymap.json   -> ~/dotfiles/zed/keymap.json
~/.config/zed/tasks.json    -> ~/dotfiles/zed/tasks.json
```